### PR TITLE
feat: add SslMode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Designed for <a href="https://github.com/roflmuffin/CounterStrikeSharp">CounterS
     "Port": 3306,
     "User": "",
     "Database": "",
-    "Password": ""
+    "Password": "",
+    "SslMode": "Preferred"
   },
   "Gameplay Settings": {
     "Free For All": true,

--- a/source/Deathmatch/Configs.cs
+++ b/source/Deathmatch/Configs.cs
@@ -136,6 +136,7 @@ public class Database
     [JsonPropertyName("User")] public string User { get; set; } = "";
     [JsonPropertyName("Database")] public string DatabaseName { get; set; } = "";
     [JsonPropertyName("Password")] public string Password { get; set; } = "";
+    [JsonPropertyName("SslMode")] public string SslMode { get; set; } = "Preferred";
 }
 
 public class SoundSettings

--- a/source/Deathmatch/Functions/Database.cs
+++ b/source/Deathmatch/Functions/Database.cs
@@ -144,7 +144,8 @@ namespace Deathmatch
                 UserID = Config.Database.User,
                 Database = Config.Database.DatabaseName,
                 Password = Config.Database.Password,
-                Pooling = true
+                Pooling = true,
+                SslMode = (Enum.TryParse(Config.Database.SslMode, true, out MySqlSslMode sslMode)) ? sslMode : MySqlSslMode.Preferred
             };
 
             return new MySqlConnection(builder.ConnectionString);


### PR DESCRIPTION
Add `SslMode` option to allow db connections using others ssl modes

Available options:
- **Preferred** - Use SSL if the server supports it. (default)
- **None** - Do not use SSL.
- **Required** - Always use SSL. Deny connection if server does not support SSL. Does not validate CA or hostname.
- **VerifyCA** - Always use SSL. Validates the CA but tolerates hostname mismatch.
- **VerifyFull** - Always use SSL. Validates CA and hostname.